### PR TITLE
fix(related-file): add editor column index when opening related file

### DIFF
--- a/src/client/relatedFiles.ts
+++ b/src/client/relatedFiles.ts
@@ -39,7 +39,7 @@ export class RelatedFiles implements Disposable {
     }
 
     if (relatedFile) {
-      commands.executeCommand('vscode.open', Uri.file(relatedFile));
+      commands.executeCommand('vscode.open', Uri.file(relatedFile), editor.viewColumn);
     }
   }
 


### PR DESCRIPTION
related files should be opened in the same editor column or pane as the
sibling file

resolves issue #51