### PR TITLE
fix(codefix): use the Aurelia attribute map to validate case of attributes, resolves #54

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
   "dependencies": {
     "aurelia-cli": "^0.29.0",
     "aurelia-dependency-injection": "^1.3.0",
+    "aurelia-templating-binding": "^1.4.0",
     "parse5": "^3.0.1",
     "reflect-metadata": "^0.1.9",
     "vscode-languageclient": "^3.5.0",

--- a/src/shared/attributeInvalidCaseFix.ts
+++ b/src/shared/attributeInvalidCaseFix.ts
@@ -1,0 +1,46 @@
+import { AttributeMap } from 'aurelia-templating-binding';
+
+export function attributeInvalidCaseFix(elementName, attributeText) {
+
+  const attributeMap = new AttributeMap({
+    isStandardSvgAttribute: () => false
+  });
+
+  const kebabCaseValidationRegex = /(.*)\.(bind|one-way|two-way|one-time|from-view|to-view|ref|call|delegate|trigger)/;
+  const match = kebabCaseValidationRegex.exec(attributeText);
+  if (match) {
+    const attribute = match[1];
+    const command = match[2];
+  
+    let fixed;
+    const element = attributeMap.elements[elementName];
+  
+    // only replace dashes in non data-* and aria-* attributes
+    let lookupProperty = attribute.toLowerCase();
+    if (/^(?!(data|aria)-).*$/g.test(lookupProperty)) {
+      lookupProperty = lookupProperty.replace('-','');
+    }
+  
+    if (element && lookupProperty in element) {
+      fixed = element[lookupProperty];
+    }
+    else if (lookupProperty in attributeMap.allElements) {
+      fixed = attributeMap.allElements[lookupProperty];
+    }
+    else {
+      fixed = attribute.split(/(?=[A-Z])/).map(s => s.toLowerCase()).join('-');
+    }
+
+    return {
+      attribute,
+      command,
+      fixed
+    };
+  }
+  
+  return {
+    attribute: attributeText,
+    command: undefined,
+    fixed: undefined
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "sourceMap": true,
         "rootDir": "."


### PR DESCRIPTION
Use the attribute map used by Aurelia to get the correct casing for an attribute.

Example:

```
<div innerHTML.bind="">
```
Should not be corrected, currently it corrects to
```
<div inner-h-t-m-l.bind="">
```
which is incorrect