### PR TITLE
feat(auto-complete): experimental auto complete from view model (behind feature toggle: smartAutocomplete)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "onCommand:extension.auBuild",
     "onCommand:extension.auRun",
     "onCommand:extension.auRunWatch",
-    "onCommand:extension.auOpenRelated"
+    "onCommand:extension.auOpenRelated",
+    "onCommand:aurelia.showViewProperties"
   ],
   "main": "./dist/src/client/main",
   "contributes": {
@@ -112,8 +113,20 @@
       {
         "command": "extension.auOpenRelated",
         "title": "Open Related Aurelia File"
+      },
+      {
+        "command": "aurelia.showViewProperties",
+        "title": "Show Aurelia view data to side"
       }
     ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "aurelia.showViewProperties",
+          "when": "resourceLangId == html"
+        }
+      ]
+    },
     "themes": [
       {
         "label": "Aurelia Dark+",
@@ -165,6 +178,14 @@
           "type": "boolean",
           "default": "true",
           "description": "Enable Aurelia validations"
+        },
+        "aurelia.featureToggles": {
+          "type": "object",
+          "description": "enable beta features",
+          "default":
+            {
+              "smartAutocomplete": false
+            }
         },
         "aurelia.autocomplete.bindings.data": {
           "type": "array",
@@ -239,6 +260,7 @@
     "vscode-textmate": "^3.1.4"
   },
   "dependencies": {
+    "aurelia-binding": "^1.2.2",
     "aurelia-cli": "^0.29.0",
     "aurelia-dependency-injection": "^1.3.0",
     "aurelia-templating-binding": "^1.4.0",

--- a/src/client/Preview/Register.ts
+++ b/src/client/Preview/Register.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+import {TextDocumentContentProvider} from './TextDocumentContentProvider';
+
+export function registerPreview(context, window, client) {
+
+  let previewUri = vscode.Uri.parse('aurelia-preview://authority/aurelia-preview');
+
+  let provider = new TextDocumentContentProvider(client);
+  let registration = vscode.workspace.registerTextDocumentContentProvider('aurelia-preview', provider);
+
+  vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
+    if (e.document === vscode.window.activeTextEditor.document) {
+      provider.update(previewUri);
+    }
+  });
+
+  vscode.window.onDidChangeTextEditorSelection((e: vscode.TextEditorSelectionChangeEvent) => {
+    if (e.textEditor === vscode.window.activeTextEditor) {
+      provider.update(previewUri);
+    }
+  });
+
+  context.subscriptions.push(vscode.commands.registerCommand('aurelia.showViewProperties', () => {
+
+    const smartAutocomplete = vscode.workspace.getConfiguration().get('aurelia.featureToggles.smartAutocomplete');
+    if (smartAutocomplete) {
+      return vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.Two, 'Aurelia view data')
+        .then(
+          (success) => {
+          }, 
+          (reason) => {
+            window.showErrorMessage(reason);
+          });
+    } else {
+      return vscode.window.showWarningMessage('This command requires the experimental feature "smartAutocomplete" to be enabled');
+    }
+
+
+	}));
+
+}
+

--- a/src/client/Preview/TextDocumentContentProvider.ts
+++ b/src/client/Preview/TextDocumentContentProvider.ts
@@ -1,0 +1,121 @@
+	import * as vscode from 'vscode';
+  import { LanguageClient } from 'vscode-languageclient';
+  import { WebComponent } from './../../server/FileParser/Model/WebComponent';
+
+  export class TextDocumentContentProvider implements vscode.TextDocumentContentProvider {
+
+    constructor(private client: LanguageClient) {
+      
+    }
+
+		private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+
+		public async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+      let editor = vscode.window.activeTextEditor;
+      if (!vscode.window.activeTextEditor.document) {
+        return Promise.resolve('<p>no data</p>');
+      }
+      let fileName = vscode.window.activeTextEditor.document.fileName;
+      let component = <WebComponent> await this.client.sendRequest('aurelia-view-information', fileName);
+
+      let headerHTML = `<h1>Component: '${component.name}'</h1>`;
+      headerHTML += '<h2>Files</h2><ul>';
+      for (let path of component.paths) {
+        headerHTML += `<li>${path}</li>`;
+      }
+      headerHTML += '</ul>';
+
+      let viewModelHTML = `<h2>no viewmodel found</h2>`;
+      if (component.viewModel) {
+        viewModelHTML = `<h2>ViewModel</h2>`;
+        viewModelHTML += `<p>type: ${component.viewModel.type}</p>`;
+        viewModelHTML += `<h3>Properties</h3>`;
+        viewModelHTML += '<ul>';
+        for (let prop of component.viewModel.properties) {
+          viewModelHTML += `<li>${prop.name} (${prop.type})</li>`;
+        }
+        viewModelHTML += '</ul>';
+        viewModelHTML += `<h3>Methods</h3>`;
+        viewModelHTML += '<ul>';
+        for (let prop of component.viewModel.methods) {
+          viewModelHTML += `<li>${prop.name} (${prop.returnType}) => (params: ${prop.parameters.join(',')})</li>`;
+        }
+        viewModelHTML += '</ul>';        
+      }
+
+      let viewHTML = `<h2>No view found</h2>`;
+      if (component.document) {
+        viewHTML = `<h2>View</h2>`;
+
+
+        if (component.document.references && component.document.references.length) {
+          viewHTML += '<h3>Require/ references in template</h3>';
+          viewHTML += `<ul>`;
+          for(let reference of component.document.references) {
+            viewHTML += `<li>path: ${reference.path}</li>`;
+            viewHTML += `<li>as: ${reference.as}</li>`;
+          }
+          viewHTML += '</ul>';
+        }
+
+        if (component.document.bindables && component.document.bindables.length) {
+          viewHTML += '<h3>bindable property on template</h3><ul>';
+          for (let bindable of component.document.bindables) {
+            viewHTML += `<li>${bindable}</li>`;
+          }
+          viewHTML += '</ul>';
+        }
+
+        if (component.document.dynamicBindables && component.document.dynamicBindables.length) {
+          viewHTML += '<h3>Attributes with bindings found in template</h3>';
+          for(let bindable of component.document.dynamicBindables) {
+            viewHTML += `
+              <ul>
+                <li>attribute name : <code>${bindable.name}</code></li>
+                <li>attribute value : <code>${bindable.value}</code></li>
+                <li>binding type: <code>${bindable.bindingType}</code></li>
+              </ul>`;
+              viewHTML += `<pre><code>${JSON.stringify(bindable.bindingData, null, 2) }</code></pre>`;
+          }
+        }
+
+        if (component.document.interpolationBindings && component.document.interpolationBindings.length) {
+          viewHTML += '<h2>String interpolation found in template</h2>';
+          for(let bindable of component.document.interpolationBindings) {
+            viewHTML += `
+              <code>${bindable.value}</code>`;
+            viewHTML += `<pre><code>${JSON.stringify(bindable.bindingData, null, 2) }</code></pre>`;
+          }
+        }
+      }
+
+      let classesHTML = '<h2>no extra classes found</h2>';
+      if (component.classes) {
+         classesHTML = '<h2>exports to this view</h2>';
+         for(let cl of component.classes) {
+          classesHTML += `<li>${cl.name}</li>`;
+         }
+         classesHTML += '</ul>';
+         
+      }
+
+      return `<body><style>pre { border: 1px solid #333; display: block; background: #1a1a1a; margin: 1rem;color: #999; }</style>
+        ${headerHTML}
+        <hr>
+        ${viewModelHTML}
+        <hr>
+        ${viewHTML}
+        <hr>
+        ${classesHTML}
+        <br><br>
+      </body>`;
+		}
+
+		get onDidChange(): vscode.Event<vscode.Uri> {
+			return this._onDidChange.event;
+		}
+
+		public update(uri: vscode.Uri) {
+			this._onDidChange.fire(uri);
+		}
+	}

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -3,6 +3,7 @@ import { ExtensionContext, OutputChannel, window, languages, SnippetString, comm
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 import AureliaCliCommands from './aureliaCLICommands';
 import { RelatedFiles } from './relatedFiles';
+import { registerPreview } from './Preview/Register';
 
 let outputChannel: OutputChannel;
 
@@ -54,6 +55,8 @@ export function activate(context: ExtensionContext) {
   };
 
   const client = new LanguageClient('html', 'Aurelia', serverOptions, clientOptions);
+  registerPreview(context, window, client);
+  
   const disposable = client.start();
   context.subscriptions.push(disposable);
 }

--- a/src/server/AureliaSettings.ts
+++ b/src/server/AureliaSettings.ts
@@ -4,4 +4,8 @@ export default class AureliaSettings {
   public bindings = {
     data : []
   }
+
+  public featureToggles = {
+    smartAutocomplete : true
+  }
 }

--- a/src/server/CodeActions/HtmlInvalidCaseCodeAction.ts
+++ b/src/server/CodeActions/HtmlInvalidCaseCodeAction.ts
@@ -1,5 +1,5 @@
 import { Diagnostic, TextEdit, Command, TextDocument } from "vscode-languageserver-types";
-import { DocumentParser } from "../DocumentParser";
+import { HTMLDocumentParser } from "./../FileParser/HTMLDocumentParser";
 import { attributeInvalidCaseFix } from "../Common/AttributeInvalidCaseFix";
 
 export class HtmlInvalidCaseCodeAction {
@@ -9,7 +9,7 @@ export class HtmlInvalidCaseCodeAction {
     const text = document.getText();
     const start = document.offsetAt(diagnostic.range.start);
     const end = document.offsetAt(diagnostic.range.end);
-    const parser = new DocumentParser();
+    const parser = new HTMLDocumentParser();
     const element = await parser.getElementAtPosition(text, start, end);
 
     const original = text.substring(start, end);

--- a/src/server/Common/AttributeInvalidCaseFix.ts
+++ b/src/server/Common/AttributeInvalidCaseFix.ts
@@ -1,5 +1,5 @@
 import { AttributeMap } from 'aurelia-templating-binding';
-import {AttributeDefinition, TagDefinition } from './../../server/DocumentParser';
+import {AttributeDefinition, TagDefinition } from './../FileParser/HTMLDocumentParser';
 
 export function attributeInvalidCaseFix(name: string, elementName: string) {
 

--- a/src/server/CompletionItemFactory.ts
+++ b/src/server/CompletionItemFactory.ts
@@ -5,7 +5,7 @@ import ElementCompletionFactory from './Completions/ElementCompletionFactory';
 import AttributeValueCompletionFactory from './Completions/AttributeValueCompletionFactory';
 import BindingCompletionFactory from './Completions/BindingCompletionFactory';
 import EmmetCompletionFactory from './Completions/EmmetCompletionFactory';
-import { DocumentParser, TagDefinition, AttributeDefinition } from './DocumentParser';
+import { HTMLDocumentParser, TagDefinition, AttributeDefinition } from './FileParser/HTMLDocumentParser';
 
 @autoinject()
 export default class CompletionItemFactory {
@@ -16,7 +16,7 @@ export default class CompletionItemFactory {
     private attributeValueCompletionFactory: AttributeValueCompletionFactory,
     private bindingCompletionFactory: BindingCompletionFactory,
     private emmetCompletionFactory: EmmetCompletionFactory,
-    private parser: DocumentParser) { }
+    private parser: HTMLDocumentParser) { }
 
   public async create(
     triggerCharacter: string,
@@ -61,7 +61,7 @@ export default class CompletionItemFactory {
         
         // inside attribute, perform attribute completion
         } else if (triggerCharacter === '"' || triggerCharacter === '\'') {
-                return this.createValueCompletion(insideTag, text, positionNumber);
+                return this.createValueCompletion(insideTag, text, positionNumber, uri);
         } else {
           return [];
         }
@@ -104,7 +104,7 @@ export default class CompletionItemFactory {
     return tags;
   }
 
-  private createValueCompletion(tag: TagDefinition, text: string, position: number) {
+  private createValueCompletion(tag: TagDefinition, text: string, position: number, uri: string) {
     let nextCharacter = text.substring(position, position + 1);
     if (/['"]/.test(nextCharacter)) {
       let attribute;
@@ -125,7 +125,7 @@ export default class CompletionItemFactory {
       if (!attribute) {
         return [];
       }
-      return this.attributeValueCompletionFactory.create(tag.name, attribute.name, attribute.binding);
+      return this.attributeValueCompletionFactory.create(tag.name, attribute.name, attribute.binding, uri);
     }
   }
 

--- a/src/server/Completions/AttributeValueCompletionFactory.ts
+++ b/src/server/Completions/AttributeValueCompletionFactory.ts
@@ -6,13 +6,21 @@ import { autoinject } from 'aurelia-dependency-injection';
 import ElementLibrary from './Library/_elementLibrary';
 import { GlobalAttributes } from './Library/_elementStructure';
 import BaseAttributeCompletionFactory from './BaseAttributeCompletionFactory';
+import {AureliaApplication} from './../FileParser/Model/AureliaApplication';
+import AureliaSettings from '../AureliaSettings';
+import { settings } from 'cluster';
+import { fileUriToPath } from './../Util/FileUriToPath';
+import { normalizePath } from './../Util/NormalizePath';
 
 @autoinject()
 export default class AttributeCompletionFactory extends BaseAttributeCompletionFactory {
 
-  constructor(library: ElementLibrary) { super(library); }
+  constructor(
+    library: ElementLibrary, 
+    private application: AureliaApplication,
+    private settings: AureliaSettings) { super(library); }
 
-  public create(elementName: string, attributeName: string, bindingName: string): Array<CompletionItem> {
+  public create(elementName: string, attributeName: string, bindingName: string, uri: string): Array<CompletionItem> {
 
     let result:Array<CompletionItem> = [];
     
@@ -37,6 +45,53 @@ export default class AttributeCompletionFactory extends BaseAttributeCompletionF
       }
     }
 
+    if (this.settings.featureToggles.smartAutocomplete) {
+      includeCodeAutoComplete(this.application, result, normalizePath(fileUriToPath(uri)));
+    }
+
     return result;
   }
+}
+
+function includeCodeAutoComplete(application, result, path) {
+  path = path.toLowerCase();
+  const compoment = application.components.find(i => i.paths.map(x => x.toLowerCase()).indexOf(path) > -1);
+
+  if (compoment) {
+    if (compoment.viewModel) {
+      compoment.viewModel.methods.forEach(x => {
+
+        let inner = '';
+        for(let i=0; i < x.parameters.length;i++) {
+          inner += `\$${i+1},`;
+        }
+        if (x.parameters.length) {
+          inner = inner.substring(0, inner.length-1);
+        }
+
+        result.push({
+          documentation: x.name,
+          insertText: `${x.name}(${inner})$0`,
+          insertTextFormat: InsertTextFormat.Snippet,
+          kind: CompletionItemKind.Method,
+          label: x.name,
+        });
+      });
+
+      compoment.viewModel.properties.forEach(x => {
+        let documentation = x.name;
+        if (x.type) {
+          documentation += ` (${x.type})`;
+        }
+
+        result.push({
+          documentation: documentation,
+          insertText: x.name,
+          insertTextFormat: InsertTextFormat.Snippet,
+          kind: CompletionItemKind.Property,
+          label: x.name,
+        })
+      });          
+    }
+  }  
 }

--- a/src/server/Completions/BindingCompletionFactory.ts
+++ b/src/server/Completions/BindingCompletionFactory.ts
@@ -4,7 +4,7 @@ import {
   InsertTextFormat, MarkedString } from 'vscode-languageserver-types';
 import { autoinject } from 'aurelia-dependency-injection';
 import ElementLibrary from './Library/_elementLibrary';
-import { TagDefinition, AttributeDefinition } from './../DocumentParser';
+import { TagDefinition, AttributeDefinition } from './../FileParser/HTMLDocumentParser';
 import BaseAttributeCompletionFactory from './BaseAttributeCompletionFactory';
 import { GlobalAttributes } from './Library/_elementStructure';
 import AureliaSettings from './../AureliaSettings';

--- a/src/server/FileParser/HTMLDocumentParser.ts
+++ b/src/server/FileParser/HTMLDocumentParser.ts
@@ -1,8 +1,8 @@
-import { AST, SAXParser, MarkupData } from 'parse5'; 
+import { AST, SAXParser, MarkupData } from 'parse5';
 import { Readable } from 'stream';
 import { Location } from 'vscode-languageserver/lib/main';
 
-export class DocumentParser {
+export class HTMLDocumentParser {
 
   public parse(text: string): Promise<Array<TagDefinition>> {
     return new Promise((resolve, reject) => {
@@ -14,7 +14,6 @@ export class DocumentParser {
 
       const parser = new SAXParser({ locationInfo: true });
       parser.on('startTag', (name, attrs, selfClosing, location) => {
-
         stack.push(new TagDefinition(
           true, 
           name, 

--- a/src/server/FileParser/Model/AureliaApplication.ts
+++ b/src/server/FileParser/Model/AureliaApplication.ts
@@ -1,0 +1,11 @@
+import {WebComponent} from './WebComponent';
+import {singleton} from 'aurelia-dependency-injection';
+
+@singleton()
+export class AureliaApplication {
+
+  constructor() {
+  }
+
+  public components: Array<WebComponent> = [];
+}

--- a/src/server/FileParser/Model/HtmlTemplateDocument.ts
+++ b/src/server/FileParser/Model/HtmlTemplateDocument.ts
@@ -1,0 +1,15 @@
+import {TemplateReference} from './TemplateReference';
+import {TagDefinition} from './../HTMLDocumentParser';
+
+export class HtmlTemplateDocument {
+  public bindables: Array<string> = [];
+  public dynamicBindables: Array<any> = [];
+  public interpolationBindings: Array<any> = [];
+  public tags: Array<TagDefinition> = [];
+  public references: Array<TemplateReference> = [];
+
+  public path: string;
+  public name: string;
+
+  
+}

--- a/src/server/FileParser/Model/TemplateReference.ts
+++ b/src/server/FileParser/Model/TemplateReference.ts
@@ -1,0 +1,3 @@
+export class TemplateReference {
+  constructor(public path?: string, public as?: string) { }
+}

--- a/src/server/FileParser/Model/ViewModelDocument.ts
+++ b/src/server/FileParser/Model/ViewModelDocument.ts
@@ -1,0 +1,5 @@
+export class ViewModelDocument {
+  public type: string;
+  public properties = [];
+  public methods = [];
+}

--- a/src/server/FileParser/Model/WebComponent.ts
+++ b/src/server/FileParser/Model/WebComponent.ts
@@ -1,0 +1,15 @@
+import {HtmlTemplateDocument} from './HtmlTemplateDocument';
+import {ViewModelDocument} from './ViewModelDocument';
+
+export class WebComponent {
+  constructor(public name: string) {
+    
+  }
+
+  public document: HtmlTemplateDocument;
+  public viewModel: ViewModelDocument;
+
+  public paths = [];
+
+  public classes = [];
+}

--- a/src/server/FileParser/Parsers/AureliaHtmlParser.ts
+++ b/src/server/FileParser/Parsers/AureliaHtmlParser.ts
@@ -1,0 +1,104 @@
+import * as Path from 'path';
+import { Parser }  from 'aurelia-binding';
+import {HtmlTemplateDocument} from './../Model/HtmlTemplateDocument';
+import {TemplateReference} from './../Model/TemplateReference';
+import {HTMLDocumentParser} from './../HTMLDocumentParser';
+import { sys } from 'typescript';
+
+export class AureliaHtmlParser {
+
+  public async processFile(path) {
+    let template = new HtmlTemplateDocument();
+    template.path = path;
+    template.name = Path.basename(path, '.html').split(/(?=[A-Z])/).map(s => s.toLowerCase()).join('-');
+
+    const fileContent = sys.readFile(path, 'utf-8');
+    if (!fileContent.startsWith('<template')) {
+      // not an Aurelia template, stop processing
+      return template;
+    }
+
+    const docParser = new HTMLDocumentParser();
+    let document = await docParser.parse(fileContent);
+    const templateTag = document.find(tag => tag.name === 'template');
+    if (templateTag) {
+      template.bindables = this.getBindableValuesFrom(templateTag);
+    }
+
+    template.references = this.getRequireImportsFrom(document);
+    template.dynamicBindables = this.getAttributeCommands(document);
+    template.interpolationBindings = this.getStringInterpolationBindings(fileContent);
+    template.tags = document;
+    return template;
+  }
+
+  private getBindableValuesFrom(templateTag) {
+    const bindableAttribute = templateTag.attributes.find(attribute => attribute.name === 'bindable');
+    if (bindableAttribute && bindableAttribute.value) {
+      return bindableAttribute.value.split(',').map(i => i.trim());
+    } else {
+      return [];
+    }
+  }
+
+  private getRequireImportsFrom(document) {
+
+      const requireStatements = document.filter(tag => tag.name === 'require' && tag.startTag);
+      let references = [];
+
+      for (let require of requireStatements) {
+        const pathAttribute = require.attributes.find(attr => attr.name === 'from');
+        const asAttribute = require.attributes.find(attr => attr.name === 'as');
+
+        let path, asElementValue;
+        if (pathAttribute) {
+          path = pathAttribute.value;
+        }
+        if (asAttribute) {
+          asElementValue = asAttribute.value;
+        }
+        references.push(new TemplateReference(path, asElementValue));
+      }
+
+      return references;
+  }
+
+  private getAttributeCommands(document) {
+
+    let bindings = [];
+    const aureliaParser = new Parser();
+    for (let element of document) {
+
+      if (element.name === 'require' || element.name === 'template') {
+        continue;
+      }
+
+      const bindingAttributes = element.attributes.filter(attr => attr.binding);
+      for (let binding of bindingAttributes) {
+        bindings.push({
+          name: binding.name,
+          value: binding.value,
+          bindingType: binding.binding,
+          bindingData: aureliaParser.parse(binding.value)
+        });
+      }
+
+    }
+    return bindings;
+  }
+
+  private getStringInterpolationBindings(fileContent) {
+    let bindings = [];
+    const aureliaParser = new Parser();
+    const interpolationRegex = /\$\{(.*)\}/g;
+    var match;
+    while (match = interpolationRegex.exec(fileContent)) {
+      bindings.push({
+        value: match[0],
+        bindingData: aureliaParser.parse(match[1])
+      });
+    }
+
+    return bindings;
+  }
+}

--- a/src/server/FileParser/ProcessFiles.ts
+++ b/src/server/FileParser/ProcessFiles.ts
@@ -1,0 +1,203 @@
+import * as Path from 'path';
+import * as FileSystem from 'fs';
+import { Parser, AccessScope }  from 'aurelia-binding';
+import { Node, SyntaxKind, SourceFile, createSourceFile, ScriptTarget, ScriptKind, 
+  forEachChild, ClassDeclaration, PropertyDeclaration, MethodDeclaration, ParameterDeclaration, sys} from "typescript";
+import {HtmlTemplateDocument} from './Model/HtmlTemplateDocument';
+
+import {WebComponent} from './Model/WebComponent';
+
+import { AureliaHtmlParser } from './Parsers/AureliaHtmlParser';
+import { ViewModelDocument } from './Model/ViewModelDocument';
+
+import { HTMLDocumentParser, TagDefinition, AttributeDefinition } from './HTMLDocumentParser';
+import { normalizePath } from './../Util/NormalizePath';
+
+
+export default class ProcessFiles {
+
+  public components = new Array<WebComponent>();
+
+  public async processPath(): Promise<void> {
+
+    const sourceDirectory = Path.join(sys.getCurrentDirectory(), '/src/');
+    const paths = sys.readDirectory(sourceDirectory, ['ts', 'js', 'html']);
+
+    for (let path of paths) {
+      path = normalizePath(path);
+      try {
+
+        const name = Path.basename(path).replace(/\.(ts|js|html)$/, '').split(/(?=[A-Z])/).map(s => s.toLowerCase()).join('-');
+        const component = this.findOrCreateWebComponentBy(name);
+
+        if (component.paths.indexOf(path) === -1) {
+          component.paths.push(path);
+        }
+
+        switch(Path.extname(path)) {
+          case '.ts':
+            const fileContent:string = sys.readFile(path, 'utf8');
+            const result = processSourceFile(path, fileContent, 'typescript');
+            component.viewModel = new ViewModelDocument();
+            component.viewModel.type = "typescript";
+            if (result && result.result.length) {
+              var defaultExport = result.result.find(cl => cl.modifiers && cl.modifiers.indexOf('default') > -1);
+              if (defaultExport) {
+                component.viewModel.properties = defaultExport.properties;
+                component.viewModel.methods = defaultExport.methods;
+              } else {
+                component.viewModel.properties = result.result[0].properties;
+                component.viewModel.methods = result.result[0].methods;
+              }
+
+              for(const classDef of result.result) {
+                if (classDef === defaultExport) {
+                  continue;
+                }
+
+                if (classDef.modifiers && classDef.modifiers.indexOf('export') > -1) {
+                  component.classes.push({
+                    name: classDef.name,
+                    methods: classDef.methods
+                  });
+                }
+              }
+            }
+
+            break;
+          case '.js':
+            //console.log('proces js', path);
+            break;
+          case '.html':
+            const htmlTemplate = await new AureliaHtmlParser().processFile(path);
+            component.document = htmlTemplate;
+            break;
+        }
+       
+        // replace it
+        const idx = this.components.findIndex(c => c.name === component.name);
+        if (idx === -1) {
+          this.components.push(component);
+        } else {
+          this.components[idx] = component;
+        }
+
+      } catch (ex) {
+        console.log(`failed to parse path ${path}`);
+        console.log(JSON.stringify(ex));
+      }
+    }
+  }
+
+  private findOrCreateWebComponentBy(name) {
+    let component = this.components.find(c => c.name === name);
+    if (!component) {
+      component = new WebComponent(name);
+    }
+    return component;
+  }
+}
+
+
+export function processSourceFile(fileName: string, content: string, type: string) {
+  let sourceFile = createSourceFile(
+        fileName, 
+        content, 
+        ScriptTarget.Latest,
+        true,
+        type === "typescript" ? ScriptKind.TS : ScriptKind.JS);
+  
+  return {
+    result: processFile(sourceFile),
+    uri: fileName
+  }
+}
+
+function processFile(sourceFile: SourceFile) {
+ 
+  let getCodeInformation = (node : Node) => {  
+    let classes = [];
+    forEachChild(node, n => {
+      if (n.kind === SyntaxKind.ClassDeclaration) {
+        classes.push(processClassDeclaration(n));
+      }
+    });
+    return classes;
+  }
+  return getCodeInformation(sourceFile);
+}
+
+function processClassDeclaration(node: Node) {
+    let properties = [];
+    let methods = [];
+    if (!node) {
+      return {properties, methods};
+    }
+
+    let declaration = (node as ClassDeclaration);
+    if (declaration.members) {
+      for (let member of declaration.members) {
+        switch(member.kind) {
+          case SyntaxKind.PropertyDeclaration:
+            let property = member as PropertyDeclaration;
+            const propertyModifiers = property.modifiers.map(i => i.getText());
+            if (propertyModifiers.indexOf("private") > -1) {
+              continue;
+            }
+            const propertyName = property.name.getText();
+            let propertyType = undefined;
+            if (property.type) {
+              propertyType = property.type.getText();
+            }
+            properties.push({
+              name: propertyName,
+              modifiers: propertyModifiers,
+              type: propertyType
+            });
+          break;
+          case SyntaxKind.GetAccessor:
+          break;
+          case SyntaxKind.MethodDeclaration:
+            let memberDeclaration = member as MethodDeclaration;
+            const memberModifiers = memberDeclaration.modifiers.map(i => i.getText());
+            if (memberModifiers.indexOf("private") > -1) {
+              continue;
+            }            
+            let memberName = memberDeclaration.name.getText();
+            let memberReturnType = undefined;
+            if (memberDeclaration.type) {
+              memberReturnType = memberDeclaration.type.getText();
+            }
+
+            let params = [];
+            if (memberDeclaration.parameters) {
+              for(let param of memberDeclaration.parameters) {
+                const p = param as ParameterDeclaration;
+                params.push(p.name.getText());
+              }
+            }
+            
+            methods.push({
+              name: memberName,
+              returnType: memberReturnType,
+              modifiers: memberModifiers,
+              parameters: params
+
+            });
+          break;
+        }
+      }
+    }
+
+    let classModifiers = [];
+    if (declaration.modifiers) {
+      classModifiers = declaration.modifiers.map(m => m.getText());
+    }
+
+    return {
+      name: declaration.name.getText(),
+      properties, 
+      methods,
+      modifiers: classModifiers
+    };
+}

--- a/src/server/Util/FileUriToPath.ts
+++ b/src/server/Util/FileUriToPath.ts
@@ -1,0 +1,20 @@
+import * as Path from 'path';
+export function fileUriToPath (uri: string) {
+
+  const rest = decodeURI(uri.substring(7));
+  const firstSlash = rest.indexOf('/');
+  let host = rest.substring(0, firstSlash);
+  let path = rest.substring(firstSlash + 1);
+
+  if ('localhost' == host) host = '';
+
+  if (host) {
+    host = Path.sep + Path.sep + host;
+  }
+  path = path.replace(/^(.+)\|/, '$1:');
+  if (Path.sep == '\\') {
+    path = path.replace(/\//g, '\\');
+  }
+  path = path.replace('%3A', ':');
+  return host + path;
+}

--- a/src/server/Util/NormalizePath.ts
+++ b/src/server/Util/NormalizePath.ts
@@ -1,0 +1,10 @@
+export function normalizePath(input) {
+  const isExtendedLengthPath = /^\\\\\?\\/.test(input);
+  const hasNonAscii = /[^\u0000-\u0080]+/.test(input);
+
+  if (isExtendedLengthPath || hasNonAscii) {
+    return input;
+  }
+
+  return input.replace(/\\/g, '/');
+} 

--- a/src/server/Validations/Attribute/InValidAttributeCasingValidation.ts
+++ b/src/server/Validations/Attribute/InValidAttributeCasingValidation.ts
@@ -1,5 +1,5 @@
 import { Diagnostic, DiagnosticSeverity, Range, TextDocument } from 'vscode-languageserver-types';
-import { AttributeDefinition, TagDefinition } from './../../DocumentParser';
+import { AttributeDefinition, TagDefinition } from './../../FileParser/HTMLDocumentParser';
 import { attributeInvalidCaseFix } from './../../Common/AttributeInvalidCaseFix';
 import { unescape } from 'querystring';
 

--- a/src/server/Validations/Attribute/OneWayDeprecatedValidation.ts
+++ b/src/server/Validations/Attribute/OneWayDeprecatedValidation.ts
@@ -1,5 +1,5 @@
 import { Diagnostic, DiagnosticSeverity, Range, TextDocument } from 'vscode-languageserver-types';
-import {AttributeDefinition, TagDefinition } from './../../DocumentParser';
+import {AttributeDefinition, TagDefinition } from './../../FileParser/HTMLDocumentParser';
 
 export class OneWayDeprecatedValidation {
   public match(attribute: AttributeDefinition) {

--- a/src/server/Validations/HtmlValidator.ts
+++ b/src/server/Validations/HtmlValidator.ts
@@ -1,5 +1,5 @@
 import { Diagnostic, DiagnosticSeverity, Range, TextDocument } from 'vscode-languageserver-types';
-import {DocumentParser, AttributeDefinition, TagDefinition } from './../DocumentParser';
+import { HTMLDocumentParser, AttributeDefinition, TagDefinition } from './../FileParser/HTMLDocumentParser';
 import { autoinject } from 'aurelia-dependency-injection';
 
 import { OneWayDeprecatedValidation } from './Attribute/OneWayDeprecatedValidation';
@@ -34,7 +34,7 @@ export class HtmlValidator {
       return Promise.resolve([]);
     }
 
-    const parser = new DocumentParser();
+    const parser = new HTMLDocumentParser();
     const documentNodes = await parser.parse(text);
   
     const diagnostics: Diagnostic[] = [];


### PR DESCRIPTION
experimental feature: smart auto complete

Basic implementation to enable autocomplete for items from the view model.
This is a very limited/ simple version, currently, it only works on bindings and hints simple properties, doesn't work on string interpolation bindings.