### PR TITLE
Fix for Cannot find module 'typescript' in v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,10 +182,9 @@
         "aurelia.featureToggles": {
           "type": "object",
           "description": "enable beta features",
-          "default":
-            {
-              "smartAutocomplete": false
-            }
+          "default": {
+            "smartAutocomplete": false
+          }
         },
         "aurelia.autocomplete.bindings.data": {
           "type": "array",
@@ -255,11 +254,11 @@
     "mocha": "^3.3.0",
     "mocha-junit-reporter": "^1.13.0",
     "tslint": "^5.2.0",
-    "typescript": "^2.3.2",
     "vscode": "^1.1.10",
     "vscode-textmate": "^3.1.4"
   },
   "dependencies": {
+    "typescript": "^2.3.2",
     "aurelia-binding": "^1.2.2",
     "aurelia-cli": "^0.29.0",
     "aurelia-dependency-injection": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -258,13 +258,13 @@
     "vscode-textmate": "^3.1.4"
   },
   "dependencies": {
-    "typescript": "^2.3.2",
     "aurelia-binding": "^1.2.2",
     "aurelia-cli": "^0.29.0",
     "aurelia-dependency-injection": "^1.3.0",
     "aurelia-templating-binding": "^1.4.0",
     "parse5": "^3.0.1",
     "reflect-metadata": "^0.1.9",
+    "typescript": "^2.3.2",
     "vscode-languageclient": "^3.5.0",
     "vscode-languageserver": "^3.5.0",
     "vscode-languageserver-types": "^3.5.0",


### PR DESCRIPTION
This is intended to fix issues #70

Since you're now importing Typescript inside `ProcessFile.ts`, you need to move the TypeScript dependency from devDependencies to `dependencies` so it gets distributed with the app otherwise the result will be the error users are encountering right now.