### PR TITLE
feat(template): aurelia syntax highlight for templates literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,21 @@
         "language": "html",
         "scopeName": "au.html",
         "path": "./syntaxes/html.json"
-      }
+      },
+      {
+        "injectTo": [
+            "source.js",
+            "source.js.jsx",
+            "source.jsx",
+            "source.ts",
+            "source.tsx"
+        ],
+        "scopeName": "inline.lit-html",
+        "path": "./syntaxes/lit-html.json",
+        "embeddedLanguages": {
+            "meta.embedded.block.html": "html"
+        }
+      } 
     ],
     "folding": {
       "markers": {

--- a/syntaxes/lit-html.json
+++ b/syntaxes/lit-html.json
@@ -1,0 +1,50 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:source.js -comment -string, L:source.jsx -comment -string,  L:source.js.jsx -comment -string, L:source.ts -comment -string, L:source.tsx -comment -string",
+	"injections": {
+		"L:source": {
+			"patterns": [
+				{
+					"match": "<",
+					"name": "invalid.illegal.bad-angle-bracket.html"
+				}
+			]
+		}
+	},
+	"patterns": [
+		{
+			"name": "string.js.taggedTemplate",
+			"contentName": "meta.embedded.block.html",
+			"begin": "(?x)(\\s+?(\\w+\\.)?(?:html|raw)\\s*)(`)",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.tagged-template.js"
+				},
+				"2": {
+					"name": "string.js"
+				},
+				"3": {
+					"name": "punctuation.definition.string.template.begin.js"
+				}
+			},
+			"end": "(`)",
+			"endCaptures": {
+				"0": {
+					"name": "string.js"
+				},
+				"1": {
+					"name": "punctuation.definition.string.template.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "source.ts#template-substitution-element"
+				},
+				{
+					"include": "au.html"
+				}
+			]
+		}
+	],
+	"scopeName": "inline.lit-html"
+}


### PR DESCRIPTION
from  https://github.com/mjbvz/vscode-lit-html

adds syntax highlighting for tagged template literals, eg
```js
$view = { 
  template : html`
    <div if.bind="value"></div>
     `
} 
```
notice the `html` tag for the string literal


* original has two more syntax files. dunno if one of those should be added
* haven't tested the ts specific issue mentioned at the original. had no problem when just renaming to ts
* no tests provided (maybe someone else can do that?)
* not documented (needed?)
* dunno if  package.json's "mimetypes" and/or "embeddedLanguages" need updating. didn't seem so