### PR TITLE
feat(template): syntax highlight for inline templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,21 @@
         "language": "html",
         "scopeName": "au.html",
         "path": "./syntaxes/html.json"
-      }
+      },
+      {
+        "injectTo": [
+            "source.js",
+            "source.js.jsx",
+            "source.jsx",
+            "source.ts",
+            "source.tsx"
+        ],
+        "scopeName": "inline.literal-template",
+        "path": "./syntaxes/literal-template.json",
+        "embeddedLanguages": {
+            "meta.embedded.block.html": "html"
+        }
+      } 
     ],
     "folding": {
       "markers": {

--- a/syntaxes/literal-template.json
+++ b/syntaxes/literal-template.json
@@ -1,0 +1,44 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:source.js -comment -string, L:source.jsx -comment -string,  L:source.js.jsx -comment -string, L:source.ts -comment -string, L:source.tsx -comment -string",
+	"injections": {
+		"L:source": {
+			"patterns": [
+				{
+					"match": "<",
+					"name": "invalid.illegal.bad-angle-bracket.html"
+				}
+			]
+		}
+	},
+	"patterns": [
+		{
+			"name": "string.js.literal.template",
+			"contentName": "meta.embedded.block.html",
+			"begin": "(\\s+?(\\w+\\.)?\\s*)(`)\\s*(?=<template(\\s+[^<]*)?>)",
+			"beginCaptures": {
+				"2": {
+					"name": "string.js"
+				},
+				"3": {
+					"name": "punctuation.definition.string.template.begin.js"
+				}
+			},
+			"end": "(?<=</template>)\\s*(`)",
+			"endCaptures": {
+				"0": {
+					"name": "string.js"
+				},
+				"1": {
+					"name": "punctuation.definition.string.template.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "au.html"
+				}
+			]
+		}
+	],
+	"scopeName": "inline.literal-template"
+}


### PR DESCRIPTION
enables aurelia syntax highlighting for template string literals in js/ts files.
eg
```js
@inlineView(`<template...>...</template>`)

$view = {template: `<template...>...</template>`}
``` 

Note: Even though the regexp has a \s* between the backtick and `<(/)template`, they need to be in the same line to be detected. dunno why. maybe someone else can fix that.

based on https://github.com/mjbvz/vscode-lit-html