### PR TITLE
Fix deprecated vscode.previewHtml (#95)

### DIFF
--- a/src/client/Preview/Register.ts
+++ b/src/client/Preview/Register.ts
@@ -24,10 +24,27 @@ export function registerPreview(context, window, client) {
 
     const smartAutocomplete = vscode.workspace.getConfiguration().get('aurelia.featureToggles.smartAutocomplete');
     if (smartAutocomplete) {
-      return vscode.commands.executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.Two, 'Aurelia view data')
+      const panel = vscode.window.createWebviewPanel(
+        'aureliaViewData',
+        'Aurelia view data',
+        vscode.ViewColumn.Two,
+      );
+
+      provider.provideTextDocumentContent(previewUri.toString())
         .then(
           (success) => {
-          }, 
+            panel.webview.html = `
+              <!DOCTYPE html>
+              <html lang="en">
+              <head>
+                  <meta charset="UTF-8">
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                  <title>Cat Coding</title>
+              </head>
+                ${success}
+              </html>
+            `
+          },
           (reason) => {
             window.showErrorMessage(reason);
           });

--- a/src/client/Preview/Register.ts
+++ b/src/client/Preview/Register.ts
@@ -36,11 +36,11 @@ export function registerPreview(context, window, client) {
             panel.webview.html = `
               <!DOCTYPE html>
               <html lang="en">
-              <head>
-                  <meta charset="UTF-8">
-                  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                  <title>Cat Coding</title>
-              </head>
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>Cat Coding</title>
+                </head>
                 ${success}
               </html>
             `

--- a/src/client/Preview/Register.ts
+++ b/src/client/Preview/Register.ts
@@ -30,7 +30,7 @@ export function registerPreview(context, window, client) {
         vscode.ViewColumn.Two,
       );
 
-      provider.provideTextDocumentContent(previewUri.toString())
+      provider.provideTextDocumentContent(previewUri)
         .then(
           (success) => {
             panel.webview.html = `

--- a/src/client/Preview/TextDocumentContentProvider.ts
+++ b/src/client/Preview/TextDocumentContentProvider.ts
@@ -5,7 +5,7 @@
   export class TextDocumentContentProvider implements vscode.TextDocumentContentProvider {
 
     constructor(private client: LanguageClient) {
-      
+
     }
 
 		private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
@@ -17,6 +17,8 @@
       }
       let fileName = vscode.window.activeTextEditor.document.fileName;
       let component = <WebComponent> await this.client.sendRequest('aurelia-view-information', fileName);
+
+      if (!component) return `No file path found for: ${fileName}`
 
       let headerHTML = `<h1>Component: '${component.name}'</h1>`;
       headerHTML += '<h2>Files</h2><ul>';
@@ -40,7 +42,7 @@
         for (let prop of component.viewModel.methods) {
           viewModelHTML += `<li>${prop.name} (${prop.returnType}) => (params: ${prop.parameters.join(',')})</li>`;
         }
-        viewModelHTML += '</ul>';        
+        viewModelHTML += '</ul>';
       }
 
       let viewHTML = `<h2>No view found</h2>`;
@@ -96,7 +98,7 @@
           classesHTML += `<li>${cl.name}</li>`;
          }
          classesHTML += '</ul>';
-         
+
       }
 
       return `<body><style>pre { border: 1px solid #333; display: block; background: #1a1a1a; margin: 1rem;color: #999; }</style>


### PR DESCRIPTION
## What was done
This PR fixes the experimental feature `smartAutocomplete`.
It broke because `vscode.previewHtml` was removed in VSCode 1.33 (March 2019), as mentioned in #95.

I used the official demo https://code.visualstudio.com/api/extension-guides/webview to guide me through the upgrade.
Also I checked some of the example PR's from closed issues referenced in https://github.com/Microsoft/vscode/issues/62630

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/30693990/61158641-dc384d00-a4f9-11e9-88aa-b076121db446.png">