### PR TITLE
feat(relatedFiles): Add more open related files support

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,16 @@
             "smartAutocomplete": false
           }
         },
+        "aurelia.relatedFiles": {
+          "type": "object",
+          "description": "Configure extensions for related files",
+          "default": {
+            "script": [".js", ".ts"],
+            "style": [".less", ".sass", ".scss", ".styl", ".css"],
+            "unit": [".spec.js", ".spec.ts"],
+            "view": [".html"]
+          }
+        },
         "aurelia.autocomplete.bindings.data": {
           "type": "array",
           "description": "Auto complete options to provide on data bindings",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "onCommand:extension.auRun",
     "onCommand:extension.auRunWatch",
     "onCommand:extension.auOpenRelated",
+    "onCommand:extension.auOpenRelatedScript",
+    "onCommand:extension.auOpenRelatedStyle",
+    "onCommand:extension.auOpenRelatedUnit",
+    "onCommand:extension.auOpenRelatedView",
     "onCommand:aurelia.showViewProperties"
   ],
   "main": "./dist/src/client/main",
@@ -129,6 +133,23 @@
         "command": "extension.auOpenRelated",
         "title": "Open Related Aurelia File"
       },
+      {
+        "command": "extension.auOpenRelatedScript",
+        "title": "Open Related Aurelia File: Script"
+      },
+      {
+        "command": "extension.auOpenRelatedStyle",
+        "title": "Open Related Aurelia File: Style"
+      },
+      {
+        "command": "extension.auOpenRelatedUnit",
+        "title": "Open Related Aurelia File: Unit"
+      },
+      {
+        "command": "extension.auOpenRelatedView",
+        "title": "Open Related Aurelia File: View"
+      },
+
       {
         "command": "aurelia.showViewProperties",
         "title": "Show Aurelia view data to side"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
       },
       {
         "command": "extension.auOpenRelated",
-        "title": "Open Related Aurelia File"
+        "title": "Switch between Aurelia view and view model"
       },
       {
         "command": "extension.auOpenRelatedScript",
@@ -220,16 +220,6 @@
           "description": "enable beta features",
           "default": {
             "smartAutocomplete": false
-          }
-        },
-        "aurelia.relatedFiles": {
-          "type": "object",
-          "description": "Configure extensions for related files",
-          "default": {
-            "script": [".js", ".ts"],
-            "style": [".less", ".sass", ".scss", ".styl", ".css"],
-            "unit": [".spec.js", ".spec.ts"],
-            "view": [".html"]
           }
         },
         "aurelia.autocomplete.bindings.data": {

--- a/src/client/relatedFiles.ts
+++ b/src/client/relatedFiles.ts
@@ -2,7 +2,6 @@
 import { commands, Disposable, TextEditor, TextEditorEdit, Uri, workspace } from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { AureliaConfigProperties } from './Model/AureliaConfigProperties';
 
 export class RelatedFiles implements Disposable {
   private disposables: Disposable[] = [];

--- a/src/client/relatedFiles.ts
+++ b/src/client/relatedFiles.ts
@@ -10,7 +10,7 @@ export class RelatedFiles implements Disposable {
   constructor() {
     this.disposables.push(commands.registerTextEditorCommand('extension.auOpenRelated', this.onOpenRelated, this));
 
-    const fileExtensionsConfig = this.getFileExtensionsFromConfig();
+    const fileExtensionsConfig = this.getRelatedFileExtensions();
     const {
       scriptExtensions,
       styleExtensions,
@@ -35,7 +35,7 @@ export class RelatedFiles implements Disposable {
   /**
    * Provide file extensions for navigating between Aurelia files.
    */
-  private getFileExtensionsFromConfig() {
+  private getRelatedFileExtensions() {
     const defaultSettings = {
       scriptExtensions: [".js", ".ts"],
       styleExtensions: [".less", ".sass", ".scss", ".styl", ".css"],
@@ -53,7 +53,7 @@ export class RelatedFiles implements Disposable {
     let relatedFile: string;
     const fileName = editor.document.fileName;
     const extension = path.extname(fileName).toLowerCase();
-    const fileExtensionsConfig = this.getFileExtensionsFromConfig();
+    const fileExtensionsConfig = this.getRelatedFileExtensions();
     const {
       viewExtensions,
       scriptExtensions,

--- a/src/client/relatedFiles.ts
+++ b/src/client/relatedFiles.ts
@@ -32,6 +32,9 @@ export class RelatedFiles implements Disposable {
     }
   }
 
+  /**
+   * Provide file extensions for navigating between Aurelia files.
+   */
   private getFileExtensionsFromConfig() {
     const defaultSettings = {
       scriptExtensions: [".js", ".ts"],
@@ -68,7 +71,12 @@ export class RelatedFiles implements Disposable {
     }
   }
 
-  private openRelatedFactory(switchToExtensions) {
+  /**
+   * Open a related Aurelia file, and
+   * return a function, which can be used by vscode's registerTextEditorCommand
+   * @param switchToExtensions Possible extensions, for target file
+   */
+  private openRelatedFactory(switchToExtensions: string[]) {
     return (editor, edit) => {
       if (!editor || !editor.document || editor.document.isUntitled) {
         return;
@@ -87,6 +95,11 @@ export class RelatedFiles implements Disposable {
     }
   }
 
+  /**
+   * @param fullPath Full path of the file, which triggered the command
+   * @param relatedExts Possible extensions, for target file
+   * @returns targetFile
+   */
   private relatedFileExists(fullPath: string, relatedExts: string[]): string {
     let targetFile: string;
     relatedExts.forEach(ext => {


### PR DESCRIPTION
## Feature

Additionally to the existing 'open related files', one is now able to directly switch to other related files.
Namely,
- scripts: eg. `.js`, `.ts`
- styles: eg. `.css`, `.less`
- unit: eg. `.spec.js`, `.spec.ts`
- view: eg. `.html`

All the extensions are configurable view the following setting
```json
	"aurelia.relatedFiles": {
		"script": ".ts",
		"style": ".less",
		"unit": ".spec.ts",
		"view": ".html"
	},
```

![au-ext-related-files](https://user-images.githubusercontent.com/30693990/62905051-18fd9b00-bd69-11e9-8f42-c5431d59a06e.gif)


## Motivation
I want to quickly switch to all related files to an Aurelia component.

## What was done
- add settings
- add 4 additional commands for related files to open files directly, instead of just toggling between `.js` and `.html`
- Changed logic from existing `openRelated` to get script extension from settings
(motivation: I believe an aurelia project will mostly have either only .js or .ts files)

