### PR TITLE
feat(autocomplete) in view

### DIFF
--- a/src/server/Completions/AttributeValueCompletionFactory.ts
+++ b/src/server/Completions/AttributeValueCompletionFactory.ts
@@ -53,7 +53,7 @@ export default class AttributeCompletionFactory extends BaseAttributeCompletionF
   }
 }
 
-function includeCodeAutoComplete(application, result, path) {
+export function includeCodeAutoComplete(application, result, path) {
   const targetPath = `/${path}`;
   const compoment = application.components.find(component => {
     return component.paths.find(path => path === targetPath);

--- a/src/server/Completions/AttributeValueCompletionFactory.ts
+++ b/src/server/Completions/AttributeValueCompletionFactory.ts
@@ -1,6 +1,6 @@
-import { 
-  CompletionItem, 
-  CompletionItemKind, 
+import {
+  CompletionItem,
+  CompletionItemKind,
   InsertTextFormat } from 'vscode-languageserver';
 import { autoinject } from 'aurelia-dependency-injection';
 import ElementLibrary from './Library/_elementLibrary';
@@ -16,14 +16,14 @@ import { normalizePath } from './../Util/NormalizePath';
 export default class AttributeCompletionFactory extends BaseAttributeCompletionFactory {
 
   constructor(
-    library: ElementLibrary, 
+    library: ElementLibrary,
     private application: AureliaApplication,
     private settings: AureliaSettings) { super(library); }
 
   public create(elementName: string, attributeName: string, bindingName: string, uri: string): Array<CompletionItem> {
 
     let result:Array<CompletionItem> = [];
-    
+
     if (bindingName === undefined || bindingName === null || bindingName === '') {
       let element = this.getElement(elementName);
 
@@ -35,12 +35,12 @@ export default class AttributeCompletionFactory extends BaseAttributeCompletionF
       if (attribute && attribute.values) {
         for (let [key, value] of attribute.values.entries()) {
           result.push({
-              documentation: value.documentation,
-              insertText: key,
-              insertTextFormat: InsertTextFormat.Snippet,
-              kind: CompletionItemKind.Property,
-              label: key,
-            });
+            documentation: value.documentation,
+            insertText: key,
+            insertTextFormat: InsertTextFormat.Snippet,
+            kind: CompletionItemKind.Property,
+            label: key,
+          });
         }
       }
     }
@@ -54,8 +54,10 @@ export default class AttributeCompletionFactory extends BaseAttributeCompletionF
 }
 
 function includeCodeAutoComplete(application, result, path) {
-  path = path.toLowerCase();
-  const compoment = application.components.find(i => i.paths.map(x => x.toLowerCase()).indexOf(path) > -1);
+  const targetPath = `/${path}`;
+  const compoment = application.components.find(component => {
+    return component.paths.find(path => path === targetPath);
+  });
 
   if (compoment) {
     if (compoment.viewModel) {
@@ -91,7 +93,7 @@ function includeCodeAutoComplete(application, result, path) {
           kind: CompletionItemKind.Property,
           label: x.name,
         })
-      });          
+      });
     }
-  }  
+  }
 }

--- a/src/server/Completions/ViewModelVariablesCompletionFactory.ts
+++ b/src/server/Completions/ViewModelVariablesCompletionFactory.ts
@@ -1,0 +1,41 @@
+import {
+  CompletionItem,
+  CompletionItemKind,
+  InsertTextFormat
+} from 'vscode-languageserver';
+import { autoinject } from 'aurelia-dependency-injection';
+import ElementLibrary from './Library/_elementLibrary';
+import BaseAttributeCompletionFactory from './BaseAttributeCompletionFactory';
+import { includeCodeAutoComplete } from './AttributeValueCompletionFactory';
+import { AureliaApplication } from './../FileParser/Model/AureliaApplication';
+import AureliaSettings from '../AureliaSettings';
+import { settings } from 'cluster';
+import { fileUriToPath } from './../Util/FileUriToPath';
+import { normalizePath } from './../Util/NormalizePath';
+
+@autoinject()
+/**
+ * Provide viewModel completion
+ *
+ * This class would provide `someVar` as a completion item
+ * @example
+ * class SomeViewModel {
+ *   public someVar: string
+ * }
+ */
+export default class ViewModelVariablesCompletionFactory extends BaseAttributeCompletionFactory {
+  constructor(
+    library: ElementLibrary,
+    private application: AureliaApplication,
+    private settings: AureliaSettings) { super(library); }
+
+  public create(uri: string): Array<CompletionItem> {
+    let result: Array<CompletionItem> = [];
+
+    if (this.settings.featureToggles.smartAutocomplete) {
+      includeCodeAutoComplete(this.application, result, normalizePath(fileUriToPath(uri)));
+    }
+
+    return result;
+  }
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,10 +1,10 @@
 import 'reflect-metadata';
-import { createConnection, 
-  IConnection, 
-  TextDocuments, 
-  InitializeParams, 
-  InitializeResult, 
-  Hover, 
+import { createConnection,
+  IConnection,
+  TextDocuments,
+  InitializeParams,
+  InitializeResult,
+  Hover,
   CompletionList,
   InitializedParams } from 'vscode-languageserver';
 import { MarkedString } from 'vscode-languageserver';
@@ -41,13 +41,13 @@ const settings = <AureliaSettings> globalContainer.get(AureliaSettings);
 
 // Register characters to lisen for
 connection.onInitialize(async (params: InitializeParams): Promise<InitializeResult> => {
-  
+
   // TODO: find better way/place to init this
   const dummy = globalContainer.get(ElementLibrary);
-  
+
   return {
     capabilities: {
-      completionProvider: { resolveProvider: false, triggerCharacters: ['<', ' ', '.', '[', '"', '\''] },
+      completionProvider: { resolveProvider: false, triggerCharacters: ['<', ' ', '.', '[', '"', '\'', '{'] },
       codeActionProvider: true,
       textDocumentSync: documents.syncKind,
     },
@@ -61,7 +61,7 @@ const codeActions = [
 connection.onCodeAction(async codeActionParams => {
   const diagnostics = codeActionParams.context.diagnostics;
   const document = documents.get(codeActionParams.textDocument.uri);
-  const commands = []; 
+  const commands = [];
   for (const diagnostic of diagnostics) {
     const action = codeActions.find(i => i.name == diagnostic.code);
     if (action) {
@@ -72,7 +72,7 @@ connection.onCodeAction(async codeActionParams => {
 });
 
 // Register and get changes to Aurelia settings
-connection.onDidChangeConfiguration(async (change) => { 
+connection.onDidChangeConfiguration(async (change) => {
   settings.quote = change.settings.aurelia.autocomplete.quotes === 'single' ? '\'' : '"';
   settings.validation = change.settings.aurelia.validation;
   settings.bindings.data = change.settings.aurelia.autocomplete.bindings.data;


### PR DESCRIPTION
## What was done

- fix instellisense in view template
  path given by vscode and `aureliaComponent` had a different format

- provide completion inside `${}`

![out](https://user-images.githubusercontent.com/30693990/65822982-decf5680-e24d-11e9-9fe3-48afaca11e86.gif)
