### PR TITLE
feat(file-watching): add documentation and refresh of web components

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "vscode": "^1.35.1"
   },
   "categories": [
-    "Languages",
+    "Programming Languages",
     "Themes",
     "Snippets"
   ],
@@ -312,7 +312,6 @@
     "mocha": "^5.1.0",
     "mocha-junit-reporter": "^1.13.0",
     "tslint": "^5.2.0",
-    "typescript": "^3.8.3",
     "vscode": "^1.1.10",
     "vscode-textmate": "^4.2.2"
   },
@@ -324,6 +323,7 @@
     "aurelia-templating-binding": "^1.5.3",
     "parse5": "^4.0.0",
     "reflect-metadata": "^0.1.9",
+    "typescript": "^3.8.3",
     "vscode-languageclient": "^4.1.3",
     "vscode-languageserver": "^4.1.2",
     "vscode-uri": "^1.0.0"

--- a/src/server/Completions/CustomElementCompletionFactory.ts
+++ b/src/server/Completions/CustomElementCompletionFactory.ts
@@ -1,11 +1,15 @@
 import {
   CompletionItem,
   CompletionItemKind,
-  InsertTextFormat, MarkedString
+  InsertTextFormat, MarkupKind, createConnection, IConnection
 } from 'vscode-languageserver';
+import * as ts from 'typescript';
 import { autoinject } from 'aurelia-dependency-injection';
 import { AureliaApplication } from "../FileParser/Model/AureliaApplication";
 import ElementLibrary from './Library/_elementLibrary';
+
+const connection: IConnection = createConnection();
+const logger = connection.console;
 
 /**
  * Get all the Custom elements from (based on aureliaApplication), and provide completion
@@ -13,22 +17,54 @@ import ElementLibrary from './Library/_elementLibrary';
 @autoinject()
 export default class CustomElementCompletionFactory {
 
-  constructor(private readonly library: ElementLibrary) { }
+  public constructor(private readonly library: ElementLibrary) { }
 
   public create(parent: string, aureliaApplication: AureliaApplication): CompletionItem[] {
-
     const result: CompletionItem[] = [];
 
     // Assumption: Every custom element has a script and a template
     const customElements = aureliaApplication.components.filter(component => component.paths.length >= 2);
-    customElements.forEach(element => {
+
+    // Map documentation to file paths if found
+    const fileClassDocumentation: {[fileName: string]: string} = {};
+
+    if (aureliaApplication.getProgram() !== undefined) {
+      const checker = aureliaApplication.getProgram().getTypeChecker();
+      for (const sourceFile of aureliaApplication.getProgram().getSourceFiles()) {
+        if (!sourceFile.isDeclarationFile) {
+          sourceFile.forEachChild((node) => {
+            if (ts.isClassDeclaration(node)) {
+              const symbol = checker.getSymbolAtLocation(node.name);
+              fileClassDocumentation[sourceFile.fileName] = ts.displayPartsToString(
+                symbol.getDocumentationComment(checker));
+            }
+          });
+        }
+      }
+    } else {
+      logger.log("CustomElement: Program missing, can't fetch documentation.");
+    }
+
+    customElements.forEach(customElement => {
+      let documentation = `\`${customElement.name}\``;
+
+      // Check if there's documentation for the file. If yes use it, otherwise fallback to documentation.
+      customElement.paths.forEach((path) => {
+        if (path.endsWith('.ts') && fileClassDocumentation[path] !== "" && fileClassDocumentation[path] !== undefined) {
+            documentation = fileClassDocumentation[path];
+        }
+      });
+
       result.push({
-        documentation: MarkedString.fromPlainText(`${element.name}`).toString(),
-        detail: `Custom Element`,
-        insertText: `${element.name}$2>$1</${element.name}>$0`,
+        documentation: {
+          kind: MarkupKind.Markdown,
+          value: documentation,
+        },
+        detail: `Au Custom Element`,
+        insertText: `${customElement.name}$2>$1</${customElement.name}>$0`,
         insertTextFormat: InsertTextFormat.Snippet,
         kind: CompletionItemKind.Property,
-        label: `Custom Element: ${element.name}`,
+        label: `Au Custom Element: ${customElement.name}`,
       });
     });
 

--- a/src/server/FileParser/Model/AureliaApplication.ts
+++ b/src/server/FileParser/Model/AureliaApplication.ts
@@ -1,11 +1,25 @@
 import { WebComponent } from './WebComponent';
 import { singleton } from 'aurelia-dependency-injection';
+import * as ts from 'typescript';
 
 @singleton()
 export class AureliaApplication {
-
-  constructor() {
-  }
-
   public components: WebComponent[] = [];
+  public watcherProgram: ts.SemanticDiagnosticsBuilderProgram;
+
+  /**
+   * getProgram gets the current program
+   *
+   * The program may be undefined if no watcher is present or no program has been initiated yet.
+   *
+   * This program can change from each call as the program is fetched
+   * from the watcher which will listen to IO changes in the tsconfig.
+   */
+  public getProgram(): ts.Program | undefined {
+    if (this.watcherProgram !== undefined) {
+      return this.watcherProgram.getProgram();
+    } else {
+      return undefined;
+    }
+  }
 }

--- a/src/server/FileParser/Model/WebComponent.ts
+++ b/src/server/FileParser/Model/WebComponent.ts
@@ -2,14 +2,14 @@ import { HtmlTemplateDocument } from './HtmlTemplateDocument';
 import { ViewModelDocument } from './ViewModelDocument';
 
 export class WebComponent {
-  constructor(public name: string) {
+  public constructor(public name: string) {
 
   }
 
   public document: HtmlTemplateDocument;
   public viewModel: ViewModelDocument;
 
-  public paths = [];
+  public paths: string[] = [];
 
   public classes = [];
 }

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -209,6 +209,10 @@ async function handlefeatureToggles({ featureToggles, extensionSettings }: Aurel
         ts.sys.fileExists,
         "tsconfig.json"
       );
+      
+      if (configPath === undefined) {
+        configPath = '../../tsconfig.json' // use config file from the extension as default
+      }
 
       // Skip watcher if no tsconfig found
       const createWatchProgram = configPath !== undefined;

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -204,7 +204,7 @@ async function handlefeatureToggles({ featureToggles, extensionSettings }: Aurel
         console.log(aureliaApplication.components.length);
       };
 
-      const configPath = ts.findConfigFile(
+      let configPath = ts.findConfigFile(
         /* searchPath */ "./",
         ts.sys.fileExists,
         "tsconfig.json"


### PR DESCRIPTION
This PR includes documentation for the custom components as well as allowing us to watch for changes when the custom component changes in terms of edit and creation. Using a TS Program
and a watchCompilerHost (while bypassing the compile), we can get an incremental change handler for ts files in the project using the tsconfig.json (if available).

This PR adresses https://github.com/aurelia/vscode-extension/issues/118, as well as the problem of needing to reload VSC for new/edited components.