### PR TITLE
fix(relatedFiles): changes to opening related files

### DIFF
--- a/src/client/relatedFiles.ts
+++ b/src/client/relatedFiles.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { commands, Disposable, TextEditor, TextEditorEdit, Uri, workspace } from 'vscode';
+import { commands, Disposable, TextEditor, TextEditorEdit, Uri, ViewColumn, workspace } from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -64,7 +64,7 @@ export class RelatedFiles implements Disposable {
     }
 
     if (relatedFile) {
-      commands.executeCommand('vscode.open', Uri.file(relatedFile), editor.viewColumn);
+      commands.executeCommand('vscode.open', Uri.file(relatedFile), ViewColumn.Active);
     }
   }
 
@@ -88,7 +88,7 @@ export class RelatedFiles implements Disposable {
       const extension = path.extname(fileName).toLowerCase();
       const relatedFile = this.relatedFileExists(fileName, switchToExtensions);
       if (relatedFile) {
-        commands.executeCommand('vscode.open', Uri.file(relatedFile), editor.viewColumn);
+        commands.executeCommand('vscode.open', Uri.file(relatedFile), ViewColumn.Active);
       }
     };
   }


### PR DESCRIPTION

#138 

Updates the second parameter to vscode.open to use the enum of ViewColumn.Active. This allows opening of the related file in the active window, versus the current behavior when updating to VS Code 1.52.1 which will open the file in a new split window. 
In versions 1.51 and below the related file would open in the active window. 
Documentation about vscode.open and the second parameter can be found at: https://code.visualstudio.com/api/references/commands
VS Code documentation about the enum: https://code.visualstudio.com/api/references/vscode-api#ViewColumn
This resolves the issue and restores functionality to before the updates to vs code.